### PR TITLE
Fix orientation overwriting

### DIFF
--- a/Sources/Media/AVMixer.swift
+++ b/Sources/Media/AVMixer.swift
@@ -146,11 +146,6 @@ extension AVMixer: Runnable {
         videoIO.view.layer?.setValue(session, forKey: "session")
         #endif
         session.startRunning()
-        #if os(iOS)
-        if let orientation:AVCaptureVideoOrientation = AVMixer.getAVCaptureVideoOrientation(UIDevice.currentDevice().orientation) {
-            self.orientation = orientation
-        }
-        #endif
     }
 
     func stopRunning() {


### PR DESCRIPTION
Fixes an [issue](https://github.com/shogo4405/lf.swift/issues/43) where the AVMixer orientation is overwritten to current device orientation during publishing start