### PR TITLE
Fixed crash in TSWriter

### DIFF
--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -19,7 +19,9 @@ class TSWriter {
             return m3u8.description
         }
         m3u8.mediaSequence = sequence - TSWriter.defaultSegmentMaxCount
-        m3u8.mediaList = Array(files[files.count - TSWriter.defaultSegmentCount..<files.count])
+        var startIndex = files.count - TSWriter.defaultSegmentCount
+        startIndex = startIndex >= 0 ? startIndex : 0
+        m3u8.mediaList = Array(files[startIndex..<files.count])
         return m3u8.description
     }
     var lockQueue:DispatchQueue = DispatchQueue(


### PR DESCRIPTION
Library periodically crashes with "out of range" exception:
<img width="1003" alt="screen shot 2016-10-03 at 17 02 43" src="https://cloud.githubusercontent.com/assets/842113/19040145/90221040-898b-11e6-82fd-3c395c469f23.png">
