### PR TITLE
remove copy-framework For FRAMEWORK target to fix ERROR ITMS-90685 wh…

### DIFF
--- a/lf.xcodeproj/project.pbxproj
+++ b/lf.xcodeproj/project.pbxproj
@@ -1246,13 +1246,12 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/XCGLogger.framework",
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "";
 		};
 		2961FF171DE2A13200A02CD7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
remove copy-framework For FRAMEWORK target to fix ERROR ITMS-90685 when upload to App Store.
A FRAMEWORK should not contain another FRAMEWORK, all the FRAMEWORKs should be managed at app level.