### PR TITLE
Remove Target Remembership to fix Carthage Build Error: /.../Carthage…

### DIFF
--- a/lf.xcodeproj/project.pbxproj
+++ b/lf.xcodeproj/project.pbxproj
@@ -52,7 +52,6 @@
 		292D8A331D8B293300DBECE2 /* MP4Sampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292D8A321D8B293300DBECE2 /* MP4Sampler.swift */; };
 		292D8A341D8B294900DBECE2 /* MP4Sampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292D8A321D8B293300DBECE2 /* MP4Sampler.swift */; };
 		292D8A351D8B294E00DBECE2 /* MP4Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29798E511CE5DF1900F5CBD0 /* MP4Reader.swift */; };
-		2930D03E1E12D12100DA2DC5 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 2930D03D1E12D12100DA2DC5 /* README.md */; };
 		2930D0411E12D35400DA2DC5 /* SampleHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2930D03F1E12D17C00DA2DC5 /* SampleHandler.swift */; };
 		2931204C1D4522CF00B14211 /* RTSPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2931204B1D4522CF00B14211 /* RTSPRequest.swift */; };
 		2931204E1D4522E400B14211 /* RTSPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2931204D1D4522E400B14211 /* RTSPResponse.swift */; };
@@ -1325,7 +1324,6 @@
 				29B876941CD70AFE00FC07DA /* SoundTransform.swift in Sources */,
 				2931204C1D4522CF00B14211 /* RTSPRequest.swift in Sources */,
 				29B876861CD70AE800FC07DA /* PacketizedElementaryStream.swift in Sources */,
-				2930D03E1E12D12100DA2DC5 /* README.md in Sources */,
 				29B876761CD70ACE00FC07DA /* HTTPRequest.swift in Sources */,
 				29B8766A1CD70AB300FC07DA /* CoreMedia+Extension.swift in Sources */,
 				299AE0E51D44EC7800D26A49 /* RTSPSocket.swift in Sources */,


### PR DESCRIPTION
Remove Target Remembership to fix Carthage Build Error: warning: no rule to process file '…/Checkouts/lf.swift/Examples/iOS/Screencast/README.md' of type net.daringfireball.markdown for architecture armv7/arm64...

Please create a new tag as the `tag 0.5.5` is not correctly work with Carthage, Thank you.