### PR TITLE
Fix crashing on ios

### DIFF
--- a/Sources/HTTP/HTTPRequest.swift
+++ b/Sources/HTTP/HTTPRequest.swift
@@ -36,7 +36,11 @@ extension HTTPRequestCompatible {
                     break
                 }
             }
-            let first:[String] = lines.first!.components(separatedBy: " ")
+            
+            guard let first:[String] = lines.first?.components(separatedBy: " "), first.count >= 3 else {
+                return
+            }
+            
             method = first[0]
             uri = first[1]
             version = first[2]

--- a/Sources/ISO/ProgramSpecific.swift
+++ b/Sources/ISO/ProgramSpecific.swift
@@ -31,6 +31,8 @@ protocol PSITableSyntax {
 class ProgramSpecific: PSIPointer, PSITableHeader, PSITableSyntax {
     static let reservedBits:UInt8 = 0x03
     static let defaultTableIDExtension:UInt16 = 1
+    
+    let mutex:Mutex = Mutex()
 
     // MARK: PSIPointer
     var pointerField:UInt8 = 0
@@ -184,6 +186,9 @@ final class ProgramMapSpecific: ProgramSpecific {
 
     override var data:[UInt8] {
         get {
+            mutex.lock()
+            defer { mutex.unlock() }
+            
             var bytes:[UInt8] = []
             elementaryStreamSpecificData.sort{ (lhs:ElementaryStreamSpecificData, rhs:ElementaryStreamSpecificData) -> Bool in
                 return lhs.elementaryPID < rhs.elementaryPID
@@ -198,6 +203,9 @@ final class ProgramMapSpecific: ProgramSpecific {
                 .bytes
         }
         set {
+            mutex.lock()
+            defer { mutex.unlock() }
+            
             let buffer:ByteArray = ByteArray(bytes: newValue)
             do {
                 PCRPID = try buffer.readUInt16() & 0x1fff

--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -156,7 +156,13 @@ class TSWriter {
         for (pid, _) in continuityCounters {
             continuityCounters[pid] = 0
         }
-        currentFileHandle?.synchronizeFile()
+        
+        nstry({
+            self.currentFileHandle?.synchronizeFile()
+        }) { exeption in
+            logger.warning("\(exeption)")
+        }
+        
         currentFileHandle?.closeFile()
         currentFileHandle = try? FileHandle(forWritingTo: url)
 

--- a/Sources/Util/Mutex.swift
+++ b/Sources/Util/Mutex.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class Mutex {
+final class Mutex: NSLocking {
 
     enum Error: Swift.Error {
         case inval
@@ -30,7 +30,7 @@ final class Mutex {
         pthread_mutex_destroy(mutex)
     }
 
-    func lock() throws {
+    func tryLock() throws {
         switch pthread_mutex_trylock(mutex) {
         case EBUSY:
             throw Mutex.Error.busy
@@ -39,6 +39,10 @@ final class Mutex {
         default:
             break
         }
+    }
+    
+    func lock() {
+        pthread_mutex_lock(mutex)
     }
 
     func unlock() {


### PR DESCRIPTION
Hi, @shogo4405 
Thanks for the awesome lib!
I found and patched some crashing bugs below.

```
1. ProgramSpecific.swift
  Cause: Bad access to array via concurrent thread
  Patch: Thread lock using mutex

2. TSWriter.swift
  Cause: Raised an exception when invoke FileHandle.synchronizeFile function
  Patch: Catch exception by nstry

3. HTTPRequest.swift
  Cause: Raised index out of range exception
  Patch: Add guard statement before take values from bytes string
```

Please confirm this :)