### PR TITLE
Add a flag to disable saving to photo library on iOS

### DIFF
--- a/Sources/Media/AVMixerRecorder.swift
+++ b/Sources/Media/AVMixerRecorder.swift
@@ -32,6 +32,9 @@ open class AVMixerRecorder: NSObject {
 
     open var writer:AVAssetWriter?
     open var fileName:String?
+    #if os(iOS)
+    open var shouldSaveToPhotoLibrary:Bool = true
+    #endif
     open var delegate:AVMixerRecorderDelegate?
     open var writerInputs:[String:AVAssetWriterInput] = [:]
     open var outputSettings:[String:[String:Any]] = AVMixerRecorder.defaultOutputSettings
@@ -247,6 +250,9 @@ extension DefaultAVMixerRecorderDelegate: AVMixerRecorderDelegate {
 
     public func didFinishWriting(_ recorder:AVMixerRecorder) {
     #if os(iOS)
+        guard recorder.shouldSaveToPhotoLibrary else {
+            return
+        }
         guard let writer:AVAssetWriter = recorder.writer else {
             return
         }


### PR DESCRIPTION
Would you please consider a flag to disable writing local recording to a photo library? 
Sometimes it's useful for logic internal to the app and doesn't need to appear in photo library.
