### PR TITLE
expired keepalive request may cause more errors than just -1005

### DIFF
--- a/Sources/RTMP/RTMPTSocket.swift
+++ b/Sources/RTMP/RTMPTSocket.swift
@@ -134,13 +134,14 @@ final class RTMPTSocket: NSObject, RTMPSocketCompatible {
             logger.error("\(error)")
 
             if let lastRequestPathComponent: String = self.lastRequestPathComponent,
-               let lastRequestData: Data = self.lastRequestData,
-               (error as NSError).code == -1005, !isRetryingRequest {
+               let lastRequestData: Data = self.lastRequestData, !isRetryingRequest {
                 if (logger.isEnabledFor(level: .verbose)) {
                     logger.verbose("Will retry request for path=\(lastRequestPathComponent)")
                 }
-                isRetryingRequest = true
-                doRequest(lastRequestPathComponent, lastRequestData, listen)
+                outputQueue.sync {
+                    isRetryingRequest = true
+                    doRequest(lastRequestPathComponent, lastRequestData, listen)
+                }
             }
 
             return


### PR DESCRIPTION
On iOS 10.3 I'm constantly getting error -1005 when the request is expired
But on iOS 9 errors are varying between:
```
Error Domain=NSURLErrorDomain Code=-1017 "cannot parse response"
Error Domain=NSURLErrorDomain Code=-1004 "Could not connect to the server."
Error Domain=NSURLErrorDomain Code=-1 "unknown error"
```
Retrying the request seems to help with all of them.